### PR TITLE
Add manual testing workflow

### DIFF
--- a/.github/workflows/test-login.yml
+++ b/.github/workflows/test-login.yml
@@ -1,0 +1,25 @@
+name: Test login
+on:
+  workflow_dispatch:
+    inputs:
+      server:
+        type: string
+        description: The url of the Octopus Instance
+        required: true
+      service_account_id:
+        type: string
+        description: The id of the service account to login for
+        required: true
+
+jobs:
+  login:
+    runs-on: ubuntu-latest
+    name: Test login to Octopus
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to Octopus
+        uses: ./
+        with:
+          server: ${{ inputs.server }}
+          service_account_id: ${{ inputs.service_account_id }}


### PR DESCRIPTION
This PR adds a manual testing workflow so that we can run the action manually against Octopus instances whilst in development. Workflows with `workflow_dispatch` are only available to use when they are part of the main branch, so we need to add this in separately, rather than alongside other work.