### PR TITLE
Fix for parsing published version

### DIFF
--- a/.changeset/rude-rockets-tie.md
+++ b/.changeset/rude-rockets-tie.md
@@ -1,0 +1,5 @@
+---
+"@octopusdeploy/login": patch
+---
+
+Fix for parsing the version for major and minor tag creation

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
         id: parse_version
         uses: madhead/semver-utils@v3.1.0
         with:
-          version: ${{ fromJSON(steps.changesets_publish.outputs.publishedPackages)[0].version }}
+          version: ${{ steps.changesets_publish.outputs.publishedPackages[0].version }}
 
       - run: echo '${{ steps.parse_version.outputs.major }}.${{ steps.parse_version.outputs.minor }}'
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,7 +69,8 @@ jobs:
         uses: madhead/semver-utils@v3.1.0
         with:
           version: ${{ fromJSON(steps.changesets_publish.outputs.publishedPackages)[0].version }}
-        if: ${{ steps.changesets_publish.outputs.published }}
+
+      - run: echo '${{ steps.parse_version.outputs.major }}.${{ steps.parse_version.outputs.minor }}'
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,18 +60,6 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Simulate published packages
-        id: changesets_publish
-        run: echo "publishedPackages=[{\"name\":\"@octopusdeploy/login\", \"version\":\"1.2.0\"}]" >> $GITHUB_OUTPUT
-
-      - name: Parse published version
-        id: parse_version
-        uses: madhead/semver-utils@v3.1.0
-        with:
-          version: ${{ steps.changesets_publish.outputs.publishedPackages[0].version }}
-
-      - run: echo '${{ steps.parse_version.outputs.major }}.${{ steps.parse_version.outputs.minor }}'
-
   publish:
     runs-on: ubuntu-latest
     name: Publish

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,6 +60,17 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Simulate published packages
+        id: changesets_publish
+        run: echo "publishedPackages=[{\"name\":\"@octopusdeploy/login\", \"version\":\"1.2.0\"}]" >> $GITHUB_OUTPUT
+
+      - name: Parse published version
+        id: parse_version
+        uses: madhead/semver-utils@v3.1.0
+        with:
+          version: ${{ fromJSON(steps.changesets_publish.outputs.publishedPackages)[0].version }}
+        if: ${{ steps.changesets_publish.outputs.published }}
+
   publish:
     runs-on: ubuntu-latest
     name: Publish
@@ -90,7 +101,7 @@ jobs:
         id: parse_version
         uses: madhead/semver-utils@v3.1.0
         with:
-          version: ${{ steps.changesets_publish.outputs.publishedPackages[0].version }}
+          version: ${{ fromJSON(steps.changesets_publish.outputs.publishedPackages)[0].version }}
         if: ${{ steps.changesets_publish.outputs.published }}
 
       - name: Tag minor version


### PR DESCRIPTION
#55 added some extra steps to the publishing job of the build workflow to tag the major and minor version when a new published version is released via changesets. The published version was parsed from the `changesets/action` outputs and then major/minor tags created.

Testing seemed like it should work, but in practice when we released a new version it didn't because the parsing didn't account for the fact that the outputs of the changesets action is json 😳. The result was an [empty version which failed to parse](https://github.com/OctopusDeploy/login/actions/runs/6319189177).

This PR fixes that up by parsing the outputs using `fromJSON` first before indexing in to the get the version. I've 🤞 tested this properly now by simulating the output of the changesets action (using the example from https://github.com/changesets/action?tab=readme-ov-file#outputs) and
- Not using fromJSON to recreate the issue: https://github.com/OctopusDeploy/login/actions/runs/6319326978/job/17160070602#step:12:28. The relevant commit here is https://github.com/OctopusDeploy/login/pull/57/commits/5e0bfc298fdd5facc930c6c638ebf515e2274461
- Using fromJSON to parse the version correctly and echo out the result: https://github.com/OctopusDeploy/login/actions/runs/6319313580/job/17160041588?pr=57#step:12:32. The relevant commit here is https://github.com/OctopusDeploy/login/pull/57/commits/4516e79f2256933019fda4728ec10adf4db23a91.

I've added a changeset so we can run it end to end, hopefully this is enough to prove that the issue is fixed and we can (finally) tag major and minor versions 😆. We'll bump another patch version without any code changes but I think this is ok.