### PR TITLE
Fix action name to be unique

### DIFF
--- a/.changeset/yellow-pugs-sniff.md
+++ b/.changeset/yellow-pugs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@octopusdeploy/login": patch
+---
+
+Fix action name to be unique

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Login
+name: Login to Octopus Deploy
 description: Login to your Octopus Server
 author: Octopus Deploy
 runs:


### PR DESCRIPTION
I went to publish the action to the marketplace and have found out that the name needs to be unique, apparently `Login` isn't allowed 🤷. This PR changes the name so it is hopefully unique.