### PR TITLE
Change to Apache-2.0 licence and add licence file to repository

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,12 @@
+Copyright (c) Octopus Deploy and contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+these files except in compliance with the License. You may obtain a copy of the
+License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octopus"
   ],
   "author": "Octopus Deploy",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/OctopusDeploy/login/issues"
   },


### PR DESCRIPTION
This PR changes the licence noted in `package.json` from `ISC` to `Apache-2.0` to match our other public repositories and adds a licence file to the repository so it can be seen.

Fixes #119 

## How to review

- Are there any concerns with the change of licence within `package.json`? 
	- The original ISC licence really only came about by a default setting when creating the npm package.
	- The repository is very recent and has no forks currently, and this change aligns the licence usage with our other repositories, but not sure if there is anything else to be aware of here.
	- There also isn't any npm package that is published from this repo, so potentially no real impact in that regard.
- Is it worth considering noting this change in release notes with a minor version bump? 