### PR TITLE
chore: Fix permissions required by release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed to tag repo and create releases
+      pull-requests: write # Needed to add comments to pull requests on release
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release


### PR DESCRIPTION
We switch from changesets to release-please for versioning and release management in #145. However when we to release a new patch version `1.0.2` today [the run failed](https://github.com/OctopusDeploy/login/actions/runs/7777882040/job/21206783126) because it was unable to add a comment to the [release PR](https://github.com/OctopusDeploy/login/pull/150).

This PR adds in permissions for writing to pull requests to hopefully address this.