### PR TITLE
Added scheduled build and test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,9 @@
 name: Build and test
 on:
+  schedule:
+    # Daily 5am australian/brisbane time (7pm UTC)
+    - cron: '0 19 * * *'
+    
   pull_request:
   push:
     branches:


### PR DESCRIPTION
As part of our sensible defaults policy, we want to Build and Test our projects daily.

This PR does not change our Build or testing process. It simply schedules it to run at 5:00 a.m. each day.

